### PR TITLE
Perf improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "pull-batch": "^1.0.0",
     "pull-block": "^1.4.0",
     "pull-pair": "^1.1.0",
+    "pull-paramap": "^1.2.2",
     "pull-pause": "0.0.2",
     "pull-pushable": "^2.2.0",
     "pull-stream": "^3.6.9",

--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -110,7 +110,7 @@ module.exports = function builder (createChunker, ipld, createReducer, _options)
         if (options.progress && typeof options.progress === 'function') {
           options.progress(chunk.byteLength)
         }
-        return Buffer.from(chunk)
+        return chunk
       }),
       asyncMap((buffer, callback) => {
         if (options.rawLeaves) {

--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -5,7 +5,8 @@ const UnixFS = require('ipfs-unixfs')
 const pull = require('pull-stream/pull')
 const values = require('pull-stream/sources/values')
 const collect = require('pull-stream/sinks/collect')
-const through = require('pull-through')
+const through = require('pull-stream/throughs/through')
+const pullThrough = require('pull-through')
 const parallel = require('async/parallel')
 const waterfall = require('async/waterfall')
 const paraMap = require('pull-paramap')
@@ -153,7 +154,7 @@ module.exports = function builder (createChunker, ipld, createReducer, _options)
           }
         ], callback)
       }),
-      through( // mark as single node if only one single node
+      pullThrough( // mark as single node if only one single node
         function onData (data) {
           count++
           if (previous) {

--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -4,12 +4,11 @@ const extend = require('deep-extend')
 const UnixFS = require('ipfs-unixfs')
 const pull = require('pull-stream/pull')
 const values = require('pull-stream/sources/values')
-const asyncMap = require('pull-stream/throughs/async-map')
-const map = require('pull-stream/throughs/map')
 const collect = require('pull-stream/sinks/collect')
 const through = require('pull-through')
 const parallel = require('async/parallel')
 const waterfall = require('async/waterfall')
+const paraMap = require('pull-paramap')
 const persist = require('../utils/persist')
 const reduce = require('./reduce')
 const {
@@ -106,50 +105,53 @@ module.exports = function builder (createChunker, ipld, createReducer, _options)
     pull(
       file.content,
       chunker,
-      map(chunk => {
+      through(chunk => {
         if (options.progress && typeof options.progress === 'function') {
           options.progress(chunk.byteLength)
         }
-        return chunk
       }),
-      asyncMap((buffer, callback) => {
-        if (options.rawLeaves) {
-          return callback(null, {
-            size: buffer.length,
-            leafSize: buffer.length,
-            data: buffer
-          })
-        }
+      paraMap((buffer, callback) => {
+        waterfall([
+          (cb) => {
+            if (options.rawLeaves) {
+              return cb(null, {
+                size: buffer.length,
+                leafSize: buffer.length,
+                data: buffer
+              })
+            }
 
-        const file = new UnixFS(options.leafType, buffer)
+            const file = new UnixFS(options.leafType, buffer)
 
-        DAGNode.create(file.marshal(), [], (err, node) => {
-          if (err) {
-            return callback(err)
+            DAGNode.create(file.marshal(), [], (err, node) => {
+              if (err) {
+                return cb(err)
+              }
+
+              cb(null, {
+                size: node.size,
+                leafSize: file.fileSize(),
+                data: node
+              })
+            })
+          },
+          (leaf, cb) => {
+            persist(leaf.data, ipld, options, (error, results) => {
+              if (error) {
+                return cb(error)
+              }
+
+              cb(null, {
+                size: leaf.size,
+                leafSize: leaf.leafSize,
+                data: results.node,
+                multihash: results.cid.buffer,
+                path: leaf.path,
+                name: ''
+              })
+            })
           }
-
-          callback(null, {
-            size: node.size,
-            leafSize: file.fileSize(),
-            data: node
-          })
-        })
-      }),
-      asyncMap((leaf, callback) => {
-        persist(leaf.data, ipld, options, (error, results) => {
-          if (error) {
-            return callback(error)
-          }
-
-          callback(null, {
-            size: leaf.size,
-            leafSize: leaf.leafSize,
-            data: results.node,
-            multihash: results.cid.buffer,
-            path: leaf.path,
-            name: ''
-          })
-        })
+        ], callback)
       }),
       through( // mark as single node if only one single node
         function onData (data) {


### PR DESCRIPTION
Fixes #9

Converts the chunk-by-chunk passing of blocks to IPLD to be done in parallel instead using [`pull-paramap`](https://www.npmjs.com/package/pull-paramap).

You can limit the concurrency in `pull-paramap` - I wasn't sure which value to use so I did a comparison using this test which uses [`pull-buffer-stream`](https://www.npmjs.com/package/pull-buffer-stream) to generate streams of buffers of random bytes:

```javascript
it('massive', function (done) {
  this.timeout(600000000)

  const size = 500000000
  let read = 0
  let lastDate = Date.now()
  let lastPercent = 0

  options.progress = (bufSize) => {
    read += bufSize

    const percent = parseInt((read / size) * 100)

    if (percent > lastPercent) {
      console.info(`${Date.now() - lastDate}`)

      lastDate = Date.now()
      lastPercent = percent
    }
  }

  pull(
    values([{
      path: '200Bytes.txt',
      content: bufferStream(size, {
        chunkSize: 256000
      })
    }]),
    importer(ipld, options),
    onEnd((err) => {
      expect(err).to.not.exist()
      done()
    })
  )
})
```

The results were (lower is better):

![image](https://user-images.githubusercontent.com/665810/50290783-af8ced00-0464-11e9-8e0b-ebcf8895750c.png)

So there's a slight overhead with 100x concurrency, but unbounded is about the same as 50x on my laptop so in this PR I leave it unbounded.

This is only 0-20% of the file being added.  I was interested by the jump so left it running in unbounded parallel mode to see if there were any other bottlenecks:

![image](https://user-images.githubusercontent.com/665810/50291071-64270e80-0465-11e9-8a3d-602ca57d3b4a.png)

The line is reasonably straight, so at least it's constant and that's ok, right?  Wrong.  Each value on the x axis is 1%, but the y axis is how long it took to ingest that 1% so it's getting slower over time.

Adding a file to IPFS is basically going at [O(n log n)](http://bigocheatsheet.com/) time which is kind of bad for large files.

What's causing this?  Turns out using `pull-stream/throughs/map` to [calculate file ingest progress](https://github.com/ipfs/js-ipfs-unixfs-importer/blob/092b5b46bdd0e593f560d76d8959c10a9b607b72/src/builder/builder.js#L109-L114) is causing this, and it allocates a new buffer for the file chunk to boot, so slow and memory inefficient.

Switching that out for a `pull-stream/throughs/through` results in the following graph:

![image](https://user-images.githubusercontent.com/665810/50291344-3e4e3980-0466-11e9-8711-a6ef8ab93921.png)

Or about 2300x faster.

Writing the file chunks in series results in:

![image](https://user-images.githubusercontent.com/665810/50291447-853c2f00-0466-11e9-9775-4f8130c7fb1f.png)

Or about 2200x faster.

So switching from series to parallel writes gets you a modest speed increase, but not changing pull stream data in-flight gets you an enormous boost.

In real-world use, this changed the time it takes to `jsipfs add` a 260MB file to a fresh repo from 13.7s to 1.95s.  By comparison`go-ipfs` takes 1.58s to add the same file to a fresh repo.