### PR TITLE
test: adds benchmark test

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ipfs-unixfs-exporter": "~0.35.4",
     "ipld": "~0.20.2",
     "multihashes": "~0.4.14",
+    "pull-buffer-stream": "^1.0.1",
     "pull-generate": "^2.2.0",
     "pull-traverse": "^1.0.3",
     "sinon": "^7.1.0"

--- a/test/benchmark.spec.js
+++ b/test/benchmark.spec.js
@@ -1,0 +1,87 @@
+/* eslint-env mocha */
+'use strict'
+
+const importer = require('../src')
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const pull = require('pull-stream/pull')
+const values = require('pull-stream/sources/values')
+const onEnd = require('pull-stream/sinks/on-end')
+const IPLD = require('ipld')
+const bufferStream = require('pull-buffer-stream')
+
+const REPEATS = 10
+const FILE_SIZE = Math.pow(2, 20) * 500 // 500MB
+const CHUNK_SIZE = 65536
+
+describe.skip('benchmark', function () {
+  this.timeout(30 * 1000)
+
+  let ipld
+
+  before((done) => {
+    IPLD.inMemory((err, resolver) => {
+      expect(err).to.not.exist()
+
+      ipld = resolver
+
+      done()
+    })
+  })
+
+  const times = []
+
+  after(() => {
+    console.info(`Percent\tms`)
+    times.forEach((time, index) => {
+      console.info(`${index}\t${parseInt(time / REPEATS)}`)
+    })
+  })
+
+  for (let i = 0; i < REPEATS; i++) {
+    it(`run ${i}`, (done) => { // eslint-disable-line no-loop-func
+      this.timeout(0)
+
+      const size = FILE_SIZE
+      let read = 0
+      let lastDate = Date.now()
+      let lastPercent = 0
+
+      const options = {
+        progress: (prog) => {
+          read += prog
+
+          const percent = parseInt((read / size) * 100)
+
+          if (percent > lastPercent) {
+            times[percent] = (times[percent] || 0) + (Date.now() - lastDate)
+
+            lastDate = Date.now()
+            lastPercent = percent
+          }
+        }
+      }
+
+      const buf = Buffer.alloc(CHUNK_SIZE).fill(0)
+
+      pull(
+        values([{
+          path: '200Bytes.txt',
+          content: bufferStream(size, {
+            chunkSize: CHUNK_SIZE,
+            generator: (num, cb) => {
+              cb(null, buf)
+            }
+          })
+        }]),
+        importer(ipld, options),
+        onEnd((err) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      )
+    })
+  }
+})

--- a/test/no
+++ b/test/no
@@ -1,0 +1,93 @@
+/* eslint-env mocha */
+'use strict'
+/*
+try {
+  require('@achingbrain/appmetrics-dash').monitor()
+} catch (error) {
+  console.error(`💥 Enabling profiling failed`, error) // eslint-disable-line no-console
+}
+*/
+const importer = require('../src')
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const pull = require('pull-stream/pull')
+const values = require('pull-stream/sources/values')
+const onEnd = require('pull-stream/sinks/on-end')
+const IPLD = require('ipld')
+const bufferStream = require('pull-buffer-stream')
+
+const REPEATS = 10
+const FILE_SIZE = Math.pow(2, 20) * 500 // 500MB
+const CHUNK_SIZE = 65536
+
+describe.skip('benchmark', function () {
+  this.timeout(30 * 1000)
+
+  let ipld
+
+  before((done) => {
+    IPLD.inMemory((err, resolver) => {
+      expect(err).to.not.exist()
+
+      ipld = resolver
+
+      done()
+    })
+  })
+
+  const times = []
+
+  after(() => {
+    console.info(`Percent\tms`)
+    times.forEach((time, index) => {
+      console.info(`${index}\t${parseInt(time/REPEATS)}`)
+    })
+  })
+
+  for (let i = 0; i < REPEATS; i++) {
+    it(`run ${i}`, (done) => {
+      this.timeout(0)
+
+      const size = FILE_SIZE
+      let read = 0
+      let lastDate = Date.now()
+      let lastPercent = 0
+
+      const options = {
+        progress: (prog) => {
+          read += prog
+
+          const percent = parseInt((read / size) * 100)
+
+          if (percent > lastPercent) {
+            times[percent] = (times[percent] || 0) + (Date.now() - lastDate)
+
+            lastDate = Date.now()
+            lastPercent = percent
+          }
+        }
+      }
+
+      const buf = Buffer.alloc(CHUNK_SIZE).fill(0)
+
+      pull(
+        values([{
+          path: '200Bytes.txt',
+          content: bufferStream(size, {
+            chunkSize: CHUNK_SIZE,
+            generator: (num, cb) => {
+              cb(null, buf)
+            }
+          })
+        }]),
+        importer(ipld, options),
+        onEnd((err) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      )
+    })
+  }
+})


### PR DESCRIPTION
Because it's useful to have this somewhere.  Skipped because we can use this to do adhoc testing and don't want it to run as part of CI.

It uses 'realistic' data sizes, so 64k incoming chunks and a 500MB file size.

It passes zeroed buffers as using crypto to generate random bytes was a bottleneck and didn't seem to add much to the test.

It runs the test 10 times then prints out the timing data collected while importing the file which you can then use to create graphs in Google Docs or whatever.