### PR TITLE
perf: switch out pull-block for bl

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  karma: {
+    browserNoActivityTimeout: 100 * 1000
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs-importer#readme",
   "devDependencies": {
-    "aegir": "ipfs/aegir#allow-config-of-browser-timeout",
+    "aegir": "^18.0.2",
     "chai": "^4.2.0",
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "rabin": false
   },
   "scripts": {
-    "test": "cross-env BROWSER_INACTIVITY_TIMEOUT=120000 aegir test",
+    "test": "aegir test",
     "test:node": "aegir test -t node",
-    "test:browser": "cross-env BROWSER_INACTIVITY_TIMEOUT=120000 aegir test -t browser",
-    "test:webworker": "cross-env BROWSER_INACTIVITY_TIMEOUT=120000 aegir test -t webworker",
+    "test:browser": "aegir test -t browser",
+    "test:webworker": "aegir test -t webworker",
     "build": "aegir build",
     "lint": "aegir lint",
     "release": "aegir release",
@@ -39,7 +39,6 @@
   "devDependencies": {
     "aegir": "ipfs/aegir#allow-config-of-browser-timeout",
     "chai": "^4.2.0",
-    "cross-env": "^5.2.0",
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",
     "ipfs-unixfs-exporter": "~0.35.4",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "async-iterator-to-pull-stream": "^1.1.0",
+    "bl": "^2.1.2",
     "cids": "~0.5.5",
     "deep-extend": "~0.6.0",
     "hamt-sharding": "~0.0.2",
@@ -60,7 +61,6 @@
     "left-pad": "^1.3.0",
     "multihashing-async": "~0.5.1",
     "pull-batch": "^1.0.0",
-    "pull-block": "^1.4.0",
     "pull-pair": "^1.1.0",
     "pull-paramap": "^1.2.2",
     "pull-pause": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "rabin": false
   },
   "scripts": {
-    "test": "aegir test",
+    "test": "cross-env BROWSER_INACTIVITY_TIMEOUT=120000 aegir test",
     "test:node": "aegir test -t node",
-    "test:browser": "aegir test -t browser",
-    "test:webworker": "aegir test -t webworker",
+    "test:browser": "cross-env BROWSER_INACTIVITY_TIMEOUT=120000 aegir test -t browser",
+    "test:webworker": "cross-env BROWSER_INACTIVITY_TIMEOUT=120000 aegir test -t webworker",
     "build": "aegir build",
     "lint": "aegir lint",
     "release": "aegir release",
@@ -37,8 +37,9 @@
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs-importer#readme",
   "devDependencies": {
-    "aegir": "^17.0.0",
+    "aegir": "ipfs/aegir#allow-config-of-browser-timeout",
     "chai": "^4.2.0",
+    "cross-env": "^5.2.0",
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",
     "ipfs-unixfs-exporter": "~0.35.4",

--- a/src/chunker/fixed-size.js
+++ b/src/chunker/fixed-size.js
@@ -1,8 +1,50 @@
 'use strict'
 
-const pullBlock = require('pull-block')
+const BufferList = require('bl')
+const through = require('pull-through')
 
 module.exports = (options) => {
   let maxSize = (typeof options === 'number') ? options : options.maxChunkSize
-  return pullBlock(maxSize, { zeroPadding: false, emitEmpty: true })
+  let bl = new BufferList()
+  let currentLength = 0
+  let emitted = false
+
+  return through(
+    function onData (buffer) {
+      bl.append(buffer)
+
+      currentLength += buffer.length
+
+      while (currentLength >= maxSize) {
+        this.queue(bl.slice(0, maxSize))
+
+        emitted = true
+
+        // throw away consumed bytes
+        if (maxSize === bl.length) {
+          bl = new BufferList()
+          currentLength = 0
+        } else {
+          const newBl = new BufferList()
+          newBl.append(bl.shallowSlice(maxSize))
+          bl = newBl
+
+          // update our offset
+          currentLength -= maxSize
+        }
+      }
+    },
+    function onEnd () {
+      if (currentLength) {
+        this.queue(bl.slice(0, currentLength))
+        emitted = true
+      }
+
+      if (!emitted) {
+        this.queue(Buffer.alloc(0))
+      }
+
+      this.queue(null)
+    }
+  )
 }

--- a/test/builder-dir-sharding.spec.js
+++ b/test/builder-dir-sharding.spec.js
@@ -267,8 +267,6 @@ describe('builder: directory sharding', function () {
     let rootHash
 
     it('imports a big dir', function (done) {
-      this.timeout(120000)
-
       const push = pushable()
       pull(
         push,

--- a/test/builder-dir-sharding.spec.js
+++ b/test/builder-dir-sharding.spec.js
@@ -266,7 +266,9 @@ describe('builder: directory sharding', function () {
     const maxDepth = 3
     let rootHash
 
-    it('imports a big dir', (done) => {
+    it('imports a big dir', function (done) {
+      this.timeout(120000)
+
       const push = pushable()
       pull(
         push,

--- a/test/builder-dir-sharding.spec.js
+++ b/test/builder-dir-sharding.spec.js
@@ -266,7 +266,7 @@ describe('builder: directory sharding', function () {
     const maxDepth = 3
     let rootHash
 
-    it('imports a big dir', function (done) {
+    it('imports a big dir', (done) => {
       const push = pushable()
       pull(
         push,

--- a/test/chunker-fixed-size.spec.js
+++ b/test/chunker-fixed-size.spec.js
@@ -66,7 +66,7 @@ describe('chunker: fixed size', function () {
     const KiB256 = 262144
 
     pull(
-      values(rawFile),
+      values([rawFile]),
       chunker(KiB256),
       collect((err, chunks) => {
         expect(err).to.not.exist()
@@ -85,7 +85,7 @@ describe('chunker: fixed size', function () {
     let file = Buffer.concat([rawFile, Buffer.from('hello')])
 
     pull(
-      values(file),
+      values([file]),
       chunker(KiB256),
       collect((err, chunks) => {
         expect(err).to.not.exist()

--- a/test/import-export.spec.js
+++ b/test/import-export.spec.js
@@ -59,7 +59,7 @@ describe('import and export', function () {
         const path = strategy + '-big.dat'
 
         pull(
-          values([{ path: path, content: values(bigFile) }]),
+          values([{ path: path, content: values([bigFile]) }]),
           importer(ipld, importerOptions),
           map((file) => {
             expect(file.path).to.eql(path)


### PR DESCRIPTION
Swaps out [`pull-block`](https://www.npmjs.com/package/pull-block) for [`bl`](https://www.npmjs.com/package/pull-block)

 * We could see a bit more of a gain by using [`bl.shallowSlice`](https://www.npmjs.com/package/bl#shallowSlice) in the `this.queue` calls but it returns instances of `BufferList` instead of `Buffer`.  These [fail `Buffer.isBuffer`](https://github.com/rvagg/bl/issues/13) which is used by the [`protons`](https://www.npmjs.com/package/protons) module further down the pull-stream pipeline so until we refactor or replace we can't use it.  Thankfully we have forked protons so can improve it, though in ipld/js-ipld-dag-pb#105 @vmx has started to use [`pbf`](https://www.npmjs.com/package/pbf) instead of `protons` so we'll have to examine the performance impact of that change.
 * When we've consumed part of the buffer we can either call [`bl.consume`](https://www.npmjs.com/package/bl#consume) to remove the bytes from the front of the buffer list, or just create a new buffer list and slice in the bytes we've yet to consume - from my testing, creating a new buffer list was faster so that's what this PR does.  Using `bl.consume` was a little slower than using `pull-block`.

Results (lower is better):

![image](https://user-images.githubusercontent.com/665810/50344210-fab90580-0521-11e9-942f-d29164991eec.png)

 * `bl.consume` was about 1% slower than `pull-block`
 * newing up BufferLists and `bl.shallowSlice`ing to remove consumed data was about 12% faster than the current `pull-block` based implementation

It uses the test from #11