### PR TITLE
fix: turn non-function progress callback into a noop

### DIFF
--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -30,6 +30,7 @@ const defaultOptions = {
 
 module.exports = function builder (createChunker, ipld, createReducer, _options) {
   const options = extend({}, defaultOptions, _options)
+  options.progress = typeof options.progress === 'function' ? options.progress : defaultOptions.progress
 
   return function (source) {
     return function (items, cb) {

--- a/test/importer.spec.js
+++ b/test/importer.spec.js
@@ -267,6 +267,23 @@ strategies.forEach((strategy) => {
       )
     })
 
+    it('survives bad progress option', (done) => {
+      pull(
+        values([{
+          path: '200Bytes.txt',
+          content: Buffer.from([0, 1, 2])
+        }]),
+        importer(ipld, {
+          ...options,
+          progress: null
+        }),
+        onEnd((err) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      )
+    })
+
     it('doesn\'t yield anything on empty source', (done) => {
       pull(
         empty(),


### PR DESCRIPTION
I figure this is a better fix than #14 because we only do the check once up front instead of for each chunk, and any decent optimising compiler should be able to strip out the noop invocation.