### PR TITLE
refactor: use ipld-in-memory module

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dirty-chai": "^2.0.1",
     "ipfs-unixfs-exporter": "~0.35.4",
     "ipld": "~0.20.2",
+    "ipld-in-memory": "^2.0.0",
     "multihashes": "~0.4.14",
     "pull-buffer-stream": "^1.0.1",
     "pull-generate": "^2.2.0",

--- a/test/benchmark.spec.js
+++ b/test/benchmark.spec.js
@@ -10,6 +10,7 @@ const pull = require('pull-stream/pull')
 const values = require('pull-stream/sources/values')
 const onEnd = require('pull-stream/sinks/on-end')
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const bufferStream = require('pull-buffer-stream')
 
 const REPEATS = 10
@@ -22,7 +23,7 @@ describe.skip('benchmark', function () {
   let ipld
 
   before((done) => {
-    IPLD.inMemory((err, resolver) => {
+    inMemory(IPLD, (err, resolver) => {
       expect(err).to.not.exist()
 
       ipld = resolver

--- a/test/builder-dir-sharding.spec.js
+++ b/test/builder-dir-sharding.spec.js
@@ -8,6 +8,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const pull = require('pull-stream/pull')
 const values = require('pull-stream/sources/values')
 const asyncMap = require('pull-stream/throughs/async-map')
@@ -24,7 +25,7 @@ describe('builder: directory sharding', function () {
   let ipld
 
   before((done) => {
-    IPLD.inMemory((err, resolver) => {
+    inMemory(IPLD, (err, resolver) => {
       expect(err).to.not.exist()
 
       ipld = resolver

--- a/test/builder-only-hash.spec.js
+++ b/test/builder-only-hash.spec.js
@@ -8,6 +8,7 @@ const pull = require('pull-stream/pull')
 const values = require('pull-stream/sources/values')
 const collect = require('pull-stream/sinks/collect')
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const CID = require('cids')
 const createBuilder = require('../src/builder')
 const FixedSizeChunker = require('../src/chunker/fixed-size')
@@ -16,7 +17,7 @@ describe('builder: onlyHash', () => {
   let ipld
 
   before((done) => {
-    IPLD.inMemory((err, resolver) => {
+    inMemory(IPLD, (err, resolver) => {
       expect(err).to.not.exist()
 
       ipld = resolver

--- a/test/builder.spec.js
+++ b/test/builder.spec.js
@@ -9,6 +9,7 @@ const values = require('pull-stream/sources/values')
 const collect = require('pull-stream/sinks/collect')
 const mh = require('multihashes')
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const eachSeries = require('async').eachSeries
 const CID = require('cids')
 const UnixFS = require('ipfs-unixfs')
@@ -19,7 +20,7 @@ describe('builder', () => {
   let ipld
 
   before((done) => {
-    IPLD.inMemory((err, resolver) => {
+    inMemory(IPLD, (err, resolver) => {
       expect(err).to.not.exist()
 
       ipld = resolver

--- a/test/hash-parity-with-go-ipfs.spec.js
+++ b/test/hash-parity-with-go-ipfs.spec.js
@@ -11,6 +11,7 @@ const values = require('pull-stream/sources/values')
 const collect = require('pull-stream/sinks/collect')
 const CID = require('cids')
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const randomByteStream = require('./helpers/finite-pseudorandom-byte-stream')
 
 const strategies = [
@@ -34,7 +35,7 @@ strategies.forEach(strategy => {
     let ipld
 
     before((done) => {
-      IPLD.inMemory((err, resolver) => {
+      inMemory(IPLD, (err, resolver) => {
         expect(err).to.not.exist()
 
         ipld = resolver

--- a/test/import-export-nested-dir.spec.js
+++ b/test/import-export-nested-dir.spec.js
@@ -5,6 +5,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const pull = require('pull-stream/pull')
 const values = require('pull-stream/sources/values')
 const collect = require('pull-stream/sinks/collect')
@@ -19,7 +20,7 @@ describe('import and export: directory', () => {
   let ipld
 
   before((done) => {
-    IPLD.inMemory((err, resolver) => {
+    inMemory(IPLD, (err, resolver) => {
       expect(err).to.not.exist()
 
       ipld = resolver

--- a/test/import-export.spec.js
+++ b/test/import-export.spec.js
@@ -6,6 +6,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const pull = require('pull-stream/pull')
 const values = require('pull-stream/sources/values')
 const concat = require('pull-stream/sinks/concat')
@@ -46,7 +47,7 @@ describe('import and export', function () {
       let ipld
 
       before((done) => {
-        IPLD.inMemory((err, resolver) => {
+        inMemory(IPLD, (err, resolver) => {
           expect(err).to.not.exist()
 
           ipld = resolver

--- a/test/importer-flush.spec.js
+++ b/test/importer-flush.spec.js
@@ -7,6 +7,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const pull = require('pull-stream/pull')
 const values = require('pull-stream/sources/values')
 const map = require('pull-stream/throughs/map')
@@ -17,7 +18,7 @@ describe('importer: flush', () => {
   let ipld
 
   before((done) => {
-    IPLD.inMemory((err, resolver) => {
+    inMemory(IPLD, (err, resolver) => {
       expect(err).to.not.exist()
 
       ipld = resolver

--- a/test/importer.spec.js
+++ b/test/importer.spec.js
@@ -17,6 +17,7 @@ const collect = require('pull-stream/sinks/collect')
 const onEnd = require('pull-stream/sinks/on-end')
 const CID = require('cids')
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const loadFixture = require('aegir/fixtures')
 const each = require('async/each')
 const waterfall = require('async/waterfall')
@@ -244,7 +245,7 @@ strategies.forEach((strategy) => {
     }
 
     before((done) => {
-      IPLD.inMemory((err, resolver) => {
+      inMemory(IPLD, (err, resolver) => {
         expect(err).to.not.exist()
 
         ipld = resolver

--- a/test/with-dag-api.spec.js
+++ b/test/with-dag-api.spec.js
@@ -17,6 +17,7 @@ const collect = require('pull-stream/sinks/collect')
 const loadFixture = require('aegir/fixtures')
 const CID = require('cids')
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 
 function stringifyMh (files) {
   return files.map((file) => {
@@ -176,7 +177,7 @@ describe('with dag-api', function () {
       }
 
       before(function (done) {
-        IPLD.inMemory((err, resolver) => {
+        inMemory(IPLD, (err, resolver) => {
           if (err) {
             return done(err)
           }


### PR DESCRIPTION
The `inMemory` util is going away to remove dependence on IPFS. This PR switches to using the `ipld-in-memory` module which does the same thing.