### PR TITLE
fix: increase test timeouts for sharding

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -2,6 +2,6 @@
 
 module.exports = {
   karma: {
-    browserNoActivityTimeout: 200 * 1000
+    browserNoActivityTimeout: 500 * 1000
   }
 }

--- a/.aegir.js
+++ b/.aegir.js
@@ -2,6 +2,6 @@
 
 module.exports = {
   karma: {
-    browserNoActivityTimeout: 100 * 1000
+    browserNoActivityTimeout: 200 * 1000
   }
 }

--- a/test/builder-dir-sharding.spec.js
+++ b/test/builder-dir-sharding.spec.js
@@ -18,9 +18,7 @@ const setImmediate = require('async/setImmediate')
 const leftPad = require('left-pad')
 const CID = require('cids')
 
-describe('builder: directory sharding', function () {
-  this.timeout(60 * 1000)
-
+describe('builder: directory sharding', () => {
   let ipld
 
   before((done) => {
@@ -166,7 +164,9 @@ describe('builder: directory sharding', function () {
     })
   })
 
-  describe('big dir', () => {
+  describe('big dir', function () {
+    this.timeout(30 * 1000)
+
     const maxDirs = 2000
     let rootHash
 
@@ -261,7 +261,9 @@ describe('builder: directory sharding', function () {
     })
   })
 
-  describe('big nested dir', () => {
+  describe('big nested dir', function () {
+    this.timeout(100 * 1000)
+
     const maxDirs = 2000
     const maxDepth = 3
     let rootHash

--- a/test/builder-dir-sharding.spec.js
+++ b/test/builder-dir-sharding.spec.js
@@ -262,7 +262,7 @@ describe('builder: directory sharding', () => {
   })
 
   describe('big nested dir', function () {
-    this.timeout(100 * 1000)
+    this.timeout(450 * 1000)
 
     const maxDirs = 2000
     const maxDepth = 3


### PR DESCRIPTION
Make the timeouts more specific to big dir tests ahead of finding out why they are so slow in the browser compared to node.