### PR TITLE
[WIP] refactor: use CID v1 with base32 encoding by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "aegir": "^18.0.2",
     "chai": "^4.2.0",
-    "cids": "~0.5.5",
+    "cids": "github:ipld/js-cid#refactor/cidv1base32-default",
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",
     "ipfs-unixfs-exporter": "~0.35.4",

--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -24,7 +24,7 @@ const defaultOptions = {
   rawLeaves: false,
   hashAlg: 'sha2-256',
   leafType: 'file',
-  cidVersion: 0,
+  cidVersion: 1,
   progress: () => {}
 }
 

--- a/src/importer/index.js
+++ b/src/importer/index.js
@@ -22,10 +22,11 @@ const defaultOptions = {
 }
 
 module.exports = function (ipld, _options) {
+  _options = _options || {}
   const options = Object.assign({}, defaultOptions, _options)
-  options.cidVersion = options.cidVersion || 1
+  options.cidVersion = options.cidVersion == null ? 1 : options.cidVersion
 
-  if (options.cidVersion > 0 && (!_options || _options.rawLeaves === undefined)) {
+  if (options.cidVersion > 0 && _options.rawLeaves === undefined) {
     // if the cid version is 1 or above, use raw leaves as this is
     // what go does.
     options.rawLeaves = true

--- a/src/importer/index.js
+++ b/src/importer/index.js
@@ -32,7 +32,7 @@ module.exports = function (ipld, _options) {
     options.rawLeaves = true
   }
 
-  if (_options && _options.hash !== undefined && _options.rawLeaves === undefined) {
+  if (_options.hash !== undefined && _options.rawLeaves === undefined) {
     // if a non-default hash alg has been specified, use raw leaves as this is
     // what go does.
     options.rawLeaves = true

--- a/src/importer/index.js
+++ b/src/importer/index.js
@@ -15,7 +15,7 @@ const defaultOptions = {
   chunker: 'fixed',
   rawLeaves: false,
   hashOnly: false,
-  cidVersion: 0,
+  cidVersion: 1,
   hash: null,
   leafType: 'file',
   hashAlg: 'sha2-256'
@@ -23,9 +23,9 @@ const defaultOptions = {
 
 module.exports = function (ipld, _options) {
   const options = Object.assign({}, defaultOptions, _options)
-  options.cidVersion = options.cidVersion || 0
+  options.cidVersion = options.cidVersion || 1
 
-  if (options.cidVersion > 0 && _options.rawLeaves === undefined) {
+  if (options.cidVersion > 0 && (!_options || _options.rawLeaves === undefined)) {
     // if the cid version is 1 or above, use raw leaves as this is
     // what go does.
     options.rawLeaves = true

--- a/src/utils/persist.js
+++ b/src/utils/persist.js
@@ -7,7 +7,7 @@ const {
 } = require('ipld-dag-pb')
 
 const defaultOptions = {
-  cidVersion: 0,
+  cidVersion: 1,
   hashAlg: 'sha2-256',
   codec: 'dag-pb'
 }

--- a/src/utils/persist.js
+++ b/src/utils/persist.js
@@ -13,7 +13,7 @@ const defaultOptions = {
 }
 
 const persist = (node, ipld, options, callback) => {
-  let cidVersion = options.cidVersion || defaultOptions.cidVersion
+  let cidVersion = options.cidVersion == null ? defaultOptions.cidVersion : options.cidVersion
   let hashAlg = options.hashAlg || defaultOptions.hashAlg
   let codec = options.codec || defaultOptions.codec
 

--- a/test/builder-dir-sharding.spec.js
+++ b/test/builder-dir-sharding.spec.js
@@ -105,7 +105,7 @@ describe('builder: directory sharding', () => {
             expect(nodes[0].path).to.be.eql(expectedHash)
             expect(new CID(nodes[0].hash).toBaseEncodedString()).to.be.eql(expectedHash)
             expect(nodes[1].path).to.be.eql(expectedHash + '/b')
-            expect(nodes[1].size).to.be.eql(29)
+            expect(nodes[1].size).to.be.eql(21)
           } catch (err) {
             return done(err)
           }

--- a/test/hash-parity-with-go-ipfs.spec.js
+++ b/test/hash-parity-with-go-ipfs.spec.js
@@ -21,9 +21,9 @@ const strategies = [
 ]
 
 const expectedHashes = {
-  flat: 'QmRgXEDv6DL8uchf7h9j8hAGG8Fq5r1UZ6Jy3TQAPxEb76',
-  balanced: 'QmVY1TFpjYKSo8LRG9oYgH4iy9AduwDvBGNhqap1Gkxme3',
-  trickle: 'QmYPsm9oVGjWECkT7KikZmrf8imggqKe8uS8Jco3qfWUCH'
+  flat: 'bafybeid7e25emp6ruqhuyrse2iwxd722gvb42hr6lycievs2sllafgk4fa',
+  balanced: 'bafybeiehl4ol4wqhzzxouk4lqwjykqulpg4qvg4g24gntqbsqrqfs6rocu',
+  trickle: 'bafybeihc3tgk6xojwmz7zl5kuzrigwcgnkxqd6dniiemohf4zemqnsqte4'
 }
 
 strategies.forEach(strategy => {

--- a/test/import-export-nested-dir.spec.js
+++ b/test/import-export-nested-dir.spec.js
@@ -16,7 +16,7 @@ const importer = require('../src')
 const exporter = require('ipfs-unixfs-exporter')
 
 describe('import and export: directory', () => {
-  const rootHash = 'QmdCrquDwd7RfZ6GCZFEVADwe8uyyw1YmF9mtAB7etDgmK'
+  const rootHash = 'bafybeig452tftu3cxeeynb76ihksupbmxt3uo2ypbqeyyg7ivy3ky7sqda'
   let ipld
 
   before((done) => {
@@ -44,19 +44,19 @@ describe('import and export: directory', () => {
         expect(err).to.not.exist()
         expect(files.map(normalizeNode).sort(byPath)).to.be.eql([
           { path: 'a/b/h',
-            multihash: 'QmWHMpCtdNjemT2F3SjyrmnBXQXwEohaZd4apcbFBhbFRC' },
+            multihash: 'bafkreihtuiwbz2hauwuwhe3qhadojlilmmbr6b4cygznq7orox6enkowhu' },
           { path: 'a/b/g',
-            multihash: 'QmQGwYzzTPcbqTiy2Nbp88gqqBqCWY4QZGfen45LFZkD5n' },
+            multihash: 'bafkreicmwczfbrrfbvji6ptb2b6zocesc2g3nc576hvfxzfikhw2ienn7m' },
           { path: 'a/b/c/d/f',
-            multihash: 'QmNVHs2dy7AjGUotsubWVncRsD3SpRXm8MgmCCQTVdVACz' },
+            multihash: 'bafkreic6on7yshnrc5kefi473zz6khlydjkfkbwxdskuo6tn5nmyrpl7ti' },
           { path: 'a/b/c/d/e',
-            multihash: 'QmYPbDKwc7oneCcEc6BcRSN5GXthTGWUCd19bTCyP9u3vH' },
+            multihash: 'bafkreifuspkigzfp4rgrdqawlt2hbjawjupcmcmrd34zrpugrvdk3y66jy' },
           { path: 'a/b/c/d',
-            multihash: 'QmQGDXr3ysARM38n7h79Tx7yD3YxuzcnZ1naG71WMojPoj' },
+            multihash: 'bafybeih327xgvrvrskzp2szg2h4mj2kppxubbb5go5dil2gdsqkdhctlga' },
           { path: 'a/b/c',
-            multihash: 'QmYTVcjYpN3hQLtJstCPE8hhEacAYjWAuTmmAAXoonamuE' },
+            multihash: 'bafybeihepdheh6iqyrmwlcsuy4wbxsbbjqvqycs6eps5wqnsmdboqq5ow4' },
           { path: 'a/b',
-            multihash: 'QmWyWYxq1GD9fEyckf5LrJv8hMW35CwfWwzDBp8bTw3NQj' },
+            multihash: 'bafybeieolgnh4uy6vp5wc5qij6ymhk3coh2mto4q57wmzzab3jfqfp66rq' },
           { path: 'a',
             multihash: rootHash }
         ])
@@ -87,13 +87,13 @@ describe('import and export: directory', () => {
           (err, files) => {
             expect(err).to.not.exist()
             expect(files.filter(fileHasContent).sort(byPath)).to.eql([
-              { path: 'QmdCrquDwd7RfZ6GCZFEVADwe8uyyw1YmF9mtAB7etDgmK/b/h',
+              { path: 'bafybeig452tftu3cxeeynb76ihksupbmxt3uo2ypbqeyyg7ivy3ky7sqda/b/h',
                 content: 'cream' },
-              { path: 'QmdCrquDwd7RfZ6GCZFEVADwe8uyyw1YmF9mtAB7etDgmK/b/g',
+              { path: 'bafybeig452tftu3cxeeynb76ihksupbmxt3uo2ypbqeyyg7ivy3ky7sqda/b/g',
                 content: 'ice' },
-              { path: 'QmdCrquDwd7RfZ6GCZFEVADwe8uyyw1YmF9mtAB7etDgmK/b/c/d/f',
+              { path: 'bafybeig452tftu3cxeeynb76ihksupbmxt3uo2ypbqeyyg7ivy3ky7sqda/b/c/d/f',
                 content: 'strawberry' },
-              { path: 'QmdCrquDwd7RfZ6GCZFEVADwe8uyyw1YmF9mtAB7etDgmK/b/c/d/e',
+              { path: 'bafybeig452tftu3cxeeynb76ihksupbmxt3uo2ypbqeyyg7ivy3ky7sqda/b/c/d/e',
                 content: 'banana' }
             ])
             done()

--- a/test/importer.spec.js
+++ b/test/importer.spec.js
@@ -618,6 +618,22 @@ strategies.forEach((strategy) => {
       )
     })
 
+    it('will import files with CID version 0', (done) => {
+      pull(
+        values([{
+          path: `TEST${Date.now()}.txt`,
+          content: values([Buffer.from('TEST' + Date.now())])
+        }]),
+        importer(ipld, { ...options, cidVersion: 0 }),
+        collect((err, results) => {
+          expect(err).to.not.exist()
+          console.log(new CID(results[0].multihash).toString())
+          expect(new CID(results[0].multihash).version).to.equal(0)
+          done()
+        })
+      )
+    })
+
     it('will import files with CID version 1', (done) => {
       const createInputFile = (path, size) => {
         const name = String(Math.random() + Date.now())

--- a/test/importer.spec.js
+++ b/test/importer.spec.js
@@ -38,15 +38,15 @@ const smallFile = loadFixture('test/fixtures/200Bytes.txt')
 const baseFiles = {
   '200Bytes.txt': {
     path: '200Bytes.txt',
-    multihash: 'QmQmZQxSKQppbsWfVzBvg59Cn3DKtsNVQ94bjAxg2h3Lb8',
+    multihash: 'bafybeibeddt74r7hfsred3rupoyk7t3yqrnc6lq2tofkbjyeancgae7yc4',
     size: 211,
     name: '',
     leafSize: 200
   },
   '1.2MiB.txt': {
     path: '1.2MiB.txt',
-    multihash: 'QmbPN6CXXWpejfQgnRYnMQcVYkFHEntHWqLNQjbkatYCh1',
-    size: 1328062,
+    multihash: 'bafybeidye343eoqqq6dbz75kytgafi4jwm2c7tybdlj2xvnj5epthnofmm',
+    size: 1330520,
     name: '',
     leafSize: 1258000
   }
@@ -56,14 +56,14 @@ const strategyBaseFiles = {
   flat: baseFiles,
   balanced: extend({}, baseFiles, {
     '1.2MiB.txt': {
-      multihash: 'QmeEGqUisUD2T6zU96PrZnCkHfXCGuQeGWKu4UoSuaZL3d',
-      size: 1335420
+      multihash: 'bafybeiaxcek2b4eedgyx4jjh4gquaof4beqemzz5ch4rmlsjsr67soz55q',
+      size: 1338154
     }
   }),
   trickle: extend({}, baseFiles, {
     '1.2MiB.txt': {
-      multihash: 'QmaiSohNUt1rBf2Lqz6ou54NHVPTbXbBoPuq9td4ekcBx4',
-      size: 1334599
+      multihash: 'bafybeicsszy6evjc47ldfasv2kh5wydapatazcuantf6nf6iwywftvggjq',
+      size: 1337301
     }
   })
 }
@@ -78,39 +78,39 @@ const strategyOverrides = {
   balanced: {
     'foo-big': {
       path: 'foo-big',
-      multihash: 'QmQ1S6eEamaf4t948etp8QiYQ9avrKCogiJnPRgNkVreLv',
-      size: 1335478
+      multihash: 'bafybeif7nmfq5sl7bvxi4o2kmqvpdri7l7jlgqe5xldeva2bz2xb64seky',
+      size: 1338214
     },
     pim: {
-      multihash: 'QmUpzaN4Jio2GB3HoPSRCMQD5EagdMWjSEGD4SGZXaCw7W',
-      size: 1335744
+      multihash: 'bafybeiaqfwmlhmlvftd7pe3d7fr2nuiwwvcd67zkh3p7u2vq6kg54sp36m',
+      size: 1338482
     },
     'pam/pum': {
-      multihash: 'QmUpzaN4Jio2GB3HoPSRCMQD5EagdMWjSEGD4SGZXaCw7W',
-      size: 1335744
+      multihash: 'bafybeiaqfwmlhmlvftd7pe3d7fr2nuiwwvcd67zkh3p7u2vq6kg54sp36m',
+      size: 1338482
     },
     pam: {
-      multihash: 'QmVoVD4fEWFLJLjvRCg4bGrziFhgECiaezp79AUfhuLgno',
-      size: 2671269
+      multihash: 'bafybeiheoaizzsupiyjc5t7l5cczonhf27f7zcoxsudfrphutnoomi7nxq',
+      size: 2676745
     }
   },
   trickle: {
     'foo-big': {
       path: 'foo-big',
-      multihash: 'QmPh6KSS7ghTqzgWhaoCiLoHFPF7HGqUxx7q9vcM5HUN4U',
-      size: 1334657
+      multihash: 'bafybeiauchq6pdjaf4nchxl7gtigktflzvlyiouemk3k5zdetzpbpgsoky',
+      size: 1337361
     },
     pim: {
-      multihash: 'QmPAn3G2x2nrq4A1fu2XUpwWtpqG4D1YXFDrU615NHvJbr',
-      size: 1334923
+      multihash: 'bafybeie3zigxtjsbyxpnhep74zofd5z6j52bpdzoxvptlr6syaqgxqcbui',
+      size: 1337629
     },
     'pam/pum': {
-      multihash: 'QmPAn3G2x2nrq4A1fu2XUpwWtpqG4D1YXFDrU615NHvJbr',
-      size: 1334923
+      multihash: 'bafybeie3zigxtjsbyxpnhep74zofd5z6j52bpdzoxvptlr6syaqgxqcbui',
+      size: 1337629
     },
     pam: {
-      multihash: 'QmZTJah1xpG9X33ZsPtDEi1tYSHGDqQMRHsGV5xKzAR2j4',
-      size: 2669627
+      multihash: 'bafybeifvnr4fzxothljw62c3cjicubsgasaxu6hsc6cwvh7opu4uaoh724',
+      size: 2675039
     }
   }
 }
@@ -184,21 +184,21 @@ strategies.forEach((strategy) => {
     }),
     foo: {
       path: 'foo',
-      multihash: 'QmQrb6KKWGo8w7zKfx2JksptY6wN7B2ysSBdKZr4xMU36d',
-      size: 320
+      multihash: 'bafybeiahadqxdlbf2w5l3bnyjmrso3zwlzeg6vcft7n6ogc3kgeg3eqcne',
+      size: 324
     },
     'foo/bar': {
       path: 'foo/bar',
-      multihash: 'Qmf5BQbTUyUAvd6Ewct83GYGnE1F6btiC3acLhR8MDxgkD',
-      size: 270
+      multihash: 'bafybeif2tllv3roheq754k4kbmlx3w6e36m3vntwe4apzufwd3aaqeqi5u',
+      size: 272
     },
     'foo-big/1.2MiB.txt': extend({}, baseFiles['1.2MiB.txt'], {
       path: 'foo-big/1.2MiB.txt'
     }),
     'foo-big': {
       path: 'foo-big',
-      multihash: 'Qma6JU3FoXU9eAzgomtmYPjzFBwVc2rRbECQpmHFiA98CJ',
-      size: 1328120
+      multihash: 'bafybeifmrcnmuli3vqni2gh5bzhq6dvn22kkpju6lak4xxjv7ut5m4qjxe',
+      size: 1330580
     },
     'pim/200Bytes.txt': extend({}, baseFiles['200Bytes.txt'], {
       path: 'pim/200Bytes.txt'
@@ -208,24 +208,24 @@ strategies.forEach((strategy) => {
     }),
     pim: {
       path: 'pim',
-      multihash: 'QmNk8VPGb3fkAQgoxctXo4Wmnr4PayFTASy4MiVXTtXqiA',
-      size: 1328386
+      multihash: 'bafybeih63r7unrizaqfpq6z337u3jh3m22ona552hpyqhdst3ign4ncnca',
+      size: 1330848
     },
     'empty-dir': {
       path: 'empty-dir',
-      multihash: 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn',
+      multihash: 'bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354',
       size: 4
     },
     'pam/pum': {
-      multihash: 'QmNk8VPGb3fkAQgoxctXo4Wmnr4PayFTASy4MiVXTtXqiA',
-      size: 1328386
+      multihash: 'bafybeih63r7unrizaqfpq6z337u3jh3m22ona552hpyqhdst3ign4ncnca',
+      size: 1330848
     },
     pam: {
-      multihash: 'QmPAixYTaYnPe795fcWcuRpo6tfwHgRKNiBHpMzoomDVN6',
-      size: 2656553
+      multihash: 'bafybeid2cwow7m4ii3523lzmippdhxpmc4qvmaezaftbo54xui662sidoa',
+      size: 2661477
     },
     '200Bytes.txt with raw leaves': extend({}, baseFiles['200Bytes.txt'], {
-      multihash: 'zb2rhXrz1gkCv8p4nUDZRohY6MzBE9C3HVTVDP72g6Du3SD9Q',
+      multihash: 'bafkreiasdth246e2lufrhjpkdvud6yci622ouqgss3wou35reukddzlut4',
       size: 200
     })
   }, strategyOverrides[strategy])
@@ -241,7 +241,8 @@ strategies.forEach((strategy) => {
       maxChildrenPerNode: 10,
       chunkerOptions: {
         maxChunkSize: 1024
-      }
+      },
+      rawLeaves: false
     }
 
     before((done) => {
@@ -308,7 +309,7 @@ strategies.forEach((strategy) => {
           expect(nodes.length).to.be.eql(1)
 
           // always yield empty node
-          expect(new CID(nodes[0].multihash).toBaseEncodedString()).to.be.eql('QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH')
+          expect(new CID(nodes[0].multihash).toBaseEncodedString()).to.be.eql('bafybeif7ztnhq65lumvvtr4ekcwd2ifwgm3awq4zfr3srh462rwyinlb4y')
           done()
         }))
     })
@@ -689,24 +690,28 @@ strategies.forEach((strategy) => {
 
     it('imports file with raw leaf nodes when specified', (done) => {
       checkLeafNodeTypes(ipld, {
+        rawLeaves: false,
         leafType: 'raw'
       }, 'raw', done)
     })
 
     it('imports file with file leaf nodes when specified', (done) => {
       checkLeafNodeTypes(ipld, {
+        rawLeaves: false,
         leafType: 'file'
       }, 'file', done)
     })
 
     it('reduces file to single node when specified', (done) => {
       checkNodeLinks(ipld, {
+        rawLeaves: false,
         reduceSingleLeafToSelf: true
       }, 0, done)
     })
 
     it('does not reduce file to single node when overidden by options', (done) => {
       checkNodeLinks(ipld, {
+        rawLeaves: false,
         reduceSingleLeafToSelf: false
       }, 1, done)
     })

--- a/test/with-dag-api.spec.js
+++ b/test/with-dag-api.spec.js
@@ -32,15 +32,15 @@ const smallFile = loadFixture('test/fixtures/200Bytes.txt')
 const baseFiles = {
   '200Bytes.txt': {
     path: '200Bytes.txt',
-    multihash: 'QmQmZQxSKQppbsWfVzBvg59Cn3DKtsNVQ94bjAxg2h3Lb8',
+    multihash: 'bafybeibeddt74r7hfsred3rupoyk7t3yqrnc6lq2tofkbjyeancgae7yc4',
     size: 211,
     name: '',
     leafSize: 200
   },
   '1.2MiB.txt': {
     path: '1.2MiB.txt',
-    multihash: 'QmbPN6CXXWpejfQgnRYnMQcVYkFHEntHWqLNQjbkatYCh1',
-    size: 1328062,
+    multihash: 'bafybeidye343eoqqq6dbz75kytgafi4jwm2c7tybdlj2xvnj5epthnofmm',
+    size: 1330520,
     name: '',
     leafSize: 1258000
   }
@@ -50,14 +50,14 @@ const strategyBaseFiles = {
   flat: baseFiles,
   balanced: extend({}, baseFiles, {
     '1.2MiB.txt': {
-      multihash: 'QmeEGqUisUD2T6zU96PrZnCkHfXCGuQeGWKu4UoSuaZL3d',
-      size: 1335420
+      multihash: 'bafybeiaxcek2b4eedgyx4jjh4gquaof4beqemzz5ch4rmlsjsr67soz55q',
+      size: 1338154
     }
   }),
   trickle: extend({}, baseFiles, {
     '1.2MiB.txt': {
-      multihash: 'QmaiSohNUt1rBf2Lqz6ou54NHVPTbXbBoPuq9td4ekcBx4',
-      size: 1334599
+      multihash: 'bafybeicsszy6evjc47ldfasv2kh5wydapatazcuantf6nf6iwywftvggjq',
+      size: 1337301
     }
   })
 }
@@ -72,39 +72,39 @@ const strategyOverrides = {
   balanced: {
     'foo-big': {
       path: 'foo-big',
-      multihash: 'QmQ1S6eEamaf4t948etp8QiYQ9avrKCogiJnPRgNkVreLv',
-      size: 1335478
+      multihash: 'bafybeif7nmfq5sl7bvxi4o2kmqvpdri7l7jlgqe5xldeva2bz2xb64seky',
+      size: 1338214
     },
     pim: {
-      multihash: 'QmUpzaN4Jio2GB3HoPSRCMQD5EagdMWjSEGD4SGZXaCw7W',
-      size: 1335744
+      multihash: 'bafybeiaqfwmlhmlvftd7pe3d7fr2nuiwwvcd67zkh3p7u2vq6kg54sp36m',
+      size: 1338482
     },
     'pam/pum': {
-      multihash: 'QmUpzaN4Jio2GB3HoPSRCMQD5EagdMWjSEGD4SGZXaCw7W',
-      size: 1335744
+      multihash: 'bafybeiaqfwmlhmlvftd7pe3d7fr2nuiwwvcd67zkh3p7u2vq6kg54sp36m',
+      size: 1338482
     },
     pam: {
       multihash: 'QmVoVD4fEWFLJLjvRCg4bGrziFhgECiaezp79AUfhuLgno',
-      size: 2671269
+      size: 2676745
     }
   },
   trickle: {
     'foo-big': {
       path: 'foo-big',
-      multihash: 'QmPh6KSS7ghTqzgWhaoCiLoHFPF7HGqUxx7q9vcM5HUN4U',
-      size: 1334657
+      multihash: 'bafybeiauchq6pdjaf4nchxl7gtigktflzvlyiouemk3k5zdetzpbpgsoky',
+      size: 1337361
     },
     pim: {
-      multihash: 'QmPAn3G2x2nrq4A1fu2XUpwWtpqG4D1YXFDrU615NHvJbr',
-      size: 1334923
+      multihash: 'bafybeie3zigxtjsbyxpnhep74zofd5z6j52bpdzoxvptlr6syaqgxqcbui',
+      size: 1337629
     },
     'pam/pum': {
-      multihash: 'QmPAn3G2x2nrq4A1fu2XUpwWtpqG4D1YXFDrU615NHvJbr',
-      size: 1334923
+      multihash: 'bafybeie3zigxtjsbyxpnhep74zofd5z6j52bpdzoxvptlr6syaqgxqcbui',
+      size: 1337629
     },
     pam: {
       multihash: 'QmZTJah1xpG9X33ZsPtDEi1tYSHGDqQMRHsGV5xKzAR2j4',
-      size: 2669627
+      size: 2675039
     }
   }
 
@@ -119,21 +119,21 @@ describe('with dag-api', function () {
       }),
       foo: {
         path: 'foo',
-        multihash: 'QmQrb6KKWGo8w7zKfx2JksptY6wN7B2ysSBdKZr4xMU36d',
-        size: 320
+        multihash: 'bafybeiahadqxdlbf2w5l3bnyjmrso3zwlzeg6vcft7n6ogc3kgeg3eqcne',
+        size: 324
       },
       'foo/bar': {
         path: 'foo/bar',
-        multihash: 'Qmf5BQbTUyUAvd6Ewct83GYGnE1F6btiC3acLhR8MDxgkD',
-        size: 270
+        multihash: 'bafybeif2tllv3roheq754k4kbmlx3w6e36m3vntwe4apzufwd3aaqeqi5u',
+        size: 272
       },
       'foo-big/1.2MiB.txt': extend({}, baseFiles['1.2MiB.txt'], {
         path: 'foo-big/1.2MiB.txt'
       }),
       'foo-big': {
         path: 'foo-big',
-        multihash: 'Qma6JU3FoXU9eAzgomtmYPjzFBwVc2rRbECQpmHFiA98CJ',
-        size: 1328120
+        multihash: 'bafybeifmrcnmuli3vqni2gh5bzhq6dvn22kkpju6lak4xxjv7ut5m4qjxe',
+        size: 1330580
       },
       'pim/200Bytes.txt': extend({}, baseFiles['200Bytes.txt'], {
         path: 'pim/200Bytes.txt'
@@ -143,21 +143,21 @@ describe('with dag-api', function () {
       }),
       pim: {
         path: 'pim',
-        multihash: 'QmNk8VPGb3fkAQgoxctXo4Wmnr4PayFTASy4MiVXTtXqiA',
-        size: 1328386
+        multihash: 'bafybeih63r7unrizaqfpq6z337u3jh3m22ona552hpyqhdst3ign4ncnca',
+        size: 1330848
       },
       'empty-dir': {
         path: 'empty-dir',
-        multihash: 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn',
+        multihash: 'bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354',
         size: 4
       },
       'pam/pum': {
-        multihash: 'QmNk8VPGb3fkAQgoxctXo4Wmnr4PayFTASy4MiVXTtXqiA',
-        size: 1328386
+        multihash: 'bafybeih63r7unrizaqfpq6z337u3jh3m22ona552hpyqhdst3ign4ncnca',
+        size: 1330848
       },
       pam: {
         multihash: 'QmPAixYTaYnPe795fcWcuRpo6tfwHgRKNiBHpMzoomDVN6',
-        size: 2656553
+        size: 2661477
       }
     }, strategyOverrides[strategy])
 
@@ -173,7 +173,8 @@ describe('with dag-api', function () {
         maxChildrenPerNode: 10,
         chunkerOptions: {
           maxChunkSize: 1024
-        }
+        },
+        rawLeaves: false
       }
 
       before(function (done) {
@@ -224,7 +225,7 @@ describe('with dag-api', function () {
             expect(err).to.not.exist()
             expect(nodes.length).to.be.eql(1)
             // always yield empty node
-            expect(new CID(nodes[0].multihash).toBaseEncodedString()).to.be.eql('QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH')
+            expect(new CID(nodes[0].multihash).toBaseEncodedString()).to.be.eql('bafybeif7ztnhq65lumvvtr4ekcwd2ifwgm3awq4zfr3srh462rwyinlb4y')
             done()
           }))
       })


### PR DESCRIPTION
BREAKING CHANGE: The module now creates and returns v1 CIDs which are base32 encoded _by default_. Also `rawLeaves` is set to `true` by default.

refs https://github.com/ipfs/js-ipfs/issues/1440

Interesting side effect - using CID v1 enables the `rawLeaves` option so the node sizes actually get smaller (I was expecting bigger nodes because of the extra version info in the CID of the links and didn't anticipate `rawLeaves` getting enabled).

* [ ] depends on https://github.com/multiformats/js-cid/pull/73