### PR TITLE
chore: update exporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cids": "~0.7.1",
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",
-    "ipfs-unixfs-exporter": "0.36.1",
+    "ipfs-unixfs-exporter": "~0.37.0",
     "ipld": "~0.24.0",
     "ipld-in-memory": "^2.0.0",
     "multihashes": "~0.4.14",


### PR DESCRIPTION
The importer & exporter use each other in their tests. The async/await conversion broke the public API quite badly so had to publish an importer on a broken build in order fix the build of the exporter. Now that is green & published the importer can get the new exporter which will fix the importer build.

Hooray.