### PR TITLE
fix: remove leftpad

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "hamt-sharding": "~0.0.2",
     "ipfs-unixfs": "~0.1.16",
     "ipld-dag-pb": "~0.17.2",
-    "left-pad": "^1.3.0",
     "multicodec": "~0.5.1",
     "multihashing-async": "~0.7.0",
     "superstruct": "~0.6.1"

--- a/src/dir-sharded.js
+++ b/src/dir-sharded.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const leftPad = require('left-pad')
 const {
   DAGLink,
   DAGNode
@@ -95,7 +94,7 @@ async function * flush (path, bucket, ipld, options) {
       continue
     }
 
-    const labelPrefix = leftPad(i.toString(16).toUpperCase(), 2, '0')
+    const labelPrefix = i.toString(16).toUpperCase().padStart(2, '0')
 
     if (Bucket.isBucket(child)) {
       let shard

--- a/test/builder-dir-sharding.spec.js
+++ b/test/builder-dir-sharding.spec.js
@@ -9,7 +9,6 @@ chai.use(require('dirty-chai'))
 const expect = chai.expect
 const IPLD = require('ipld')
 const inMemory = require('ipld-in-memory')
-const leftPad = require('left-pad')
 const all = require('async-iterator-all')
 const last = require('async-iterator-last')
 
@@ -133,7 +132,7 @@ describe('builder: directory sharding', () => {
         [Symbol.asyncIterator]: async function * () {
           for (let i = 0; i < maxDirs; i++) {
             yield {
-              path: 'big/' + leftPad(i.toString(), 4, '0'),
+              path: 'big/' + i.toString().padStart(4, '0'),
               content: Buffer.from(i.toString())
             }
           }
@@ -152,7 +151,7 @@ describe('builder: directory sharding', () => {
         [Symbol.asyncIterator]: async function * () {
           for (let i = 0; i < maxDirs; i++) {
             yield {
-              path: 'big/' + leftPad(i.toString(), 4, '0'),
+              path: 'big/' + i.toString().padStart(4, '0'),
               content: Buffer.from(i.toString())
             }
           }
@@ -196,7 +195,7 @@ describe('builder: directory sharding', () => {
             }
 
             yield {
-              path: dir.concat(leftPad(i.toString(), 4, '0')).join('/'),
+              path: dir.concat(i.toString().padStart(4, '0')).join('/'),
               content: Buffer.from(i.toString())
             }
 
@@ -267,7 +266,7 @@ describe('builder: directory sharding', () => {
           const pathElements = path.split('/')
           expect(pathElements.length).to.equal(depth + 1)
           const lastElement = pathElements[pathElements.length - 1]
-          expect(lastElement).to.equal(leftPad(index.toString(), 4, '0'))
+          expect(lastElement).to.equal(index.toString().padStart(4, '0'))
           expect(entries[path].content).to.equal(index.toString())
         }
         index++


### PR DESCRIPTION
left-pad is deprecated in favor of String.prototype.padStart()