### PR TITLE
perf: avoid unnecessary buffer copy

### DIFF
--- a/src/chunker/rabin.js
+++ b/src/chunker/rabin.js
@@ -51,14 +51,11 @@ const jsRabin = () => {
   return async function * (source, options) {
     const r = await create(options.bits, options.min, options.max, options.window)
     const buffers = new BufferList()
-    let pending = []
 
     for await (const chunk of source) {
       buffers.append(chunk)
-      pending.push(chunk)
 
-      const sizes = r.fingerprint(Buffer.concat(pending))
-      pending = []
+      const sizes = r.fingerprint(chunk)
 
       for (let i = 0; i < sizes.length; i++) {
         var size = sizes[i]


### PR DESCRIPTION
The `pending` array is emptied every iteration so just pass the file chunk directly into the rabin chunker instead.