### PR TITLE
feat: support passing DAGNodes as content

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The `import` function returns an async iterator takes a source async iterator th
 ```js
 {
   path: 'a name',
-  content: (Buffer or iterator emitting Buffers),
+  content: (Buffer, (async) iterator emitting Buffers or a DAGNode with a marshaled UnixFS entry as it's Data property),
   mtime: (Number representing seconds since (positive) or before (negative) the Unix Epoch),
   mode: (Number representing ugo-rwx, setuid, setguid and sticky bit)
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "ipld-in-memory": "^3.0.0",
     "it-buffer-stream": "^1.0.0",
     "it-last": "^1.0.0",
-    "multihashes": "^0.4.14",
     "nyc": "^15.0.0",
     "sinon": "^8.0.4"
   },

--- a/src/dag-builder/dag-node.js
+++ b/src/dag-builder/dag-node.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const UnixFS = require('ipfs-unixfs')
+const persist = require('../utils/persist')
+
+const dagNodeBuilder = async (path, node, ipld, options) => {
+  const cid = await persist(node, ipld, options)
+
+  return {
+    cid,
+    path,
+    unixfs: UnixFS.unmarshal(node.Data),
+    node
+  }
+}
+
+module.exports = dagNodeBuilder

--- a/src/utils/persist.js
+++ b/src/utils/persist.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const mh = require('multihashes')
+const {
+  multihash
+} = require('multihashing-async')
 const mc = require('multicodec')
 
 const persist = (node, ipld, options) => {
@@ -14,10 +16,10 @@ const persist = (node, ipld, options) => {
   }
 
   if (isNaN(options.hashAlg)) {
-    options.hashAlg = mh.names[options.hashAlg]
+    options.hashAlg = multihash.names[options.hashAlg]
   }
 
-  if (options.hashAlg !== mh.names['sha2-256']) {
+  if (options.hashAlg !== multihash.names['sha2-256']) {
     options.cidVersion = 1
   }
 

--- a/test/builder.spec.js
+++ b/test/builder.spec.js
@@ -4,7 +4,9 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
-const mh = require('multihashes')
+const {
+  multihash
+} = require('multihashing-async')
 const IPLD = require('ipld')
 const inMemory = require('ipld-in-memory')
 const UnixFS = require('ipfs-unixfs')
@@ -18,7 +20,7 @@ describe('builder', () => {
     ipld = await inMemory(IPLD)
   })
 
-  const testMultihashes = Object.keys(mh.names).slice(1, 40)
+  const testMultihashes = Object.keys(multihash.names).slice(1, 40)
   const opts = {
     strategy: 'flat',
     chunker: 'fixed',
@@ -48,7 +50,7 @@ describe('builder', () => {
       expect(imported).to.exist()
 
       // Verify multihash has been encoded using hashAlg
-      expect(mh.decode(imported.cid.multihash).name).to.equal(hashAlg)
+      expect(multihash.decode(imported.cid.multihash).name).to.equal(hashAlg)
 
       // Fetch using hashAlg encoded multihash
       const node = await ipld.get(imported.cid)
@@ -77,7 +79,7 @@ describe('builder', () => {
       const imported = await (await first(builder([inputFile], ipld, options)))()
 
       expect(imported).to.exist()
-      expect(mh.decode(imported.cid.multihash).name).to.equal(hashAlg)
+      expect(multihash.decode(imported.cid.multihash).name).to.equal(hashAlg)
     }
   })
 
@@ -96,7 +98,7 @@ describe('builder', () => {
 
       const imported = await (await first(builder([Object.assign({}, inputFile)], ipld, options)))()
 
-      expect(mh.decode(imported.cid.multihash).name).to.equal(hashAlg)
+      expect(multihash.decode(imported.cid.multihash).name).to.equal(hashAlg)
 
       // Fetch using hashAlg encoded multihash
       const node = await ipld.get(imported.cid)


### PR DESCRIPTION
Sometimes you just want to do some DAG manipulations, you don't necessarily want to chunk and create files.

This PR allows you to pass `DAGNode`s as `.content` for entries being imported, so you can combine the `unixfs-exporter` and `unixfs-importer` as a tree walker do fun things with metadata at a reasonable speed.

Also removes the `multihashes` dep in favour of the one exported by `multihashing-async`.