### PR TITLE
feat: allow overriding of internal functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,17 +151,21 @@ The input's file paths and directory structure will be preserved in the [`dag-pb
 Several aspects of the importer are overridable by specifying functions as part of the options object with these keys:
 
 - `chunkValidator` (function): Optional function that supports the signature `async function * (source, options)`
+  - This function takes input from the `content` field of imported entries. It should transform them into `Buffer`s, throwing an error if it cannot.
   - It should yield `Buffer` objects constructed from the `source` or throw an `Error`
 - `chunker` (function): Optional function that supports the signature `async function * (source, options)` where `source` is an async generator and `options` is an options object
   - It should yield `Buffer` objects.
 - `bufferImporter` (function): Optional function that supports the signature `async function * (entry, source, ipld, options)`
+  - This function should read `Buffer`s from `source` and persist them using `ipld.put` or similar
   - `entry` is the `{ path, content }` entry, `source` is an async generator that yields Buffers
   - It should yield functions that return a Promise that resolves to an object with the properties `{ cid, unixfs, size }` where `cid` is a [CID], `unixfs` is a [UnixFS] entry and `size` is a `Number` that represents the serialized size of the [IPLD] node that holds the buffer data.
   - Values will be pulled from this generator in parallel - the amount of parallelisation is controlled by the `blockWriteConcurrency` option (default: 10)
 - `dagBuilder` (function): Optional function that supports the signature `async function * (source, ipld, options)`
+  - This function should read `{ path, content }` entries from `source` and turn them into DAGs
   - It should yield a `function` that returns a `Promise` that resolves to `{ cid, path, unixfs, node }` where `cid` is a `CID`, `path` is a string, `unixfs` is a UnixFS entry and `node` is a `DAGNode`.
   - Values will be pulled from this generator in parallel - the amount of parallelisation is controlled by the `fileImportConcurrency` option (default: 50)
 - `treeBuilder` (function): Optional function that supports the signature `async function * (source, ipld, options)`
+  - This function should read `{ cid, path, unixfs, node }` entries from `source` and place them in a directory structure
   - It should yield an object with the properties `{ cid, path, unixfs, size }` where `cid` is a `CID`, `path` is a string, `unixfs` is a UnixFS entry and `size` is a `Number`.
 
 [ipld-resolver instance]: https://github.com/ipld/js-ipld-resolver

--- a/src/dag-builder/dir.js
+++ b/src/dag-builder/dir.js
@@ -21,7 +21,7 @@ const dirBuilder = async (item, ipld, options) => {
     cid,
     path,
     unixfs,
-    node
+    size: node.size
   }
 }
 

--- a/src/dag-builder/file/buffer-importer.js
+++ b/src/dag-builder/file/buffer-importer.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const UnixFS = require('ipfs-unixfs')
+const persist = require('../../utils/persist')
+const {
+  DAGNode
+} = require('ipld-dag-pb')
+
+async function * bufferImporter (file, source, ipld, options) {
+  for await (const buffer of source) {
+    yield async () => {
+      options.progress(buffer.length)
+      let node
+      let unixfs
+      let size
+
+      const opts = {
+        ...options
+      }
+
+      if (options.rawLeaves) {
+        node = buffer
+        size = buffer.length
+
+        opts.codec = 'raw'
+        opts.cidVersion = 1
+      } else {
+        unixfs = new UnixFS({
+          type: options.leafType,
+          data: buffer,
+          mtime: file.mtime,
+          mode: file.mode
+        })
+
+        node = new DAGNode(unixfs.marshal())
+        size = node.size
+      }
+
+      const cid = await persist(node, ipld, opts)
+
+      return {
+        cid: cid,
+        unixfs,
+        size
+      }
+    }
+  }
+}
+
+module.exports = bufferImporter

--- a/src/dir-flat.js
+++ b/src/dir-flat.js
@@ -65,7 +65,7 @@ class DirFlat extends Dir {
         }
       }
 
-      links.push(new DAGLink(children[i], child.node.length || child.node.size, child.cid))
+      links.push(new DAGLink(children[i], child.size, child.cid))
     }
 
     const unixfs = new UnixFS({
@@ -84,7 +84,7 @@ class DirFlat extends Dir {
       cid,
       unixfs,
       path,
-      node
+      size: node.size
     }
   }
 }

--- a/src/dir-sharded.js
+++ b/src/dir-sharded.js
@@ -107,7 +107,7 @@ async function * flush (path, bucket, ipld, shardRoot, options) {
         shard = subShard
       }
 
-      links.push(new DAGLink(labelPrefix, shard.node.size, shard.cid))
+      links.push(new DAGLink(labelPrefix, shard.size, shard.cid))
     } else if (typeof child.value.flush === 'function') {
       const dir = child.value
       let flushedDir
@@ -119,7 +119,7 @@ async function * flush (path, bucket, ipld, shardRoot, options) {
       }
 
       const label = labelPrefix + child.key
-      links.push(new DAGLink(label, flushedDir.node.size, flushedDir.cid))
+      links.push(new DAGLink(label, flushedDir.size, flushedDir.cid))
     } else {
       const value = child.value
 
@@ -155,8 +155,8 @@ async function * flush (path, bucket, ipld, shardRoot, options) {
 
   yield {
     cid,
-    node,
     unixfs: dir,
-    path
+    path,
+    size: node.size
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const dagBuilder = require('./dag-builder')
-const treeBuilder = require('./tree-builder')
 const parallelBatch = require('it-parallel-batch')
 const mergeOptions = require('merge-options').bind({ ignoreUndefined: true })
 
@@ -30,7 +28,9 @@ const defaultOptions = {
   pin: true,
   recursive: false,
   hidden: false,
-  preload: true
+  preload: true,
+  chunkValidator: null,
+  importBuffer: null
 }
 
 module.exports = async function * (source, ipld, options = {}) {
@@ -56,6 +56,22 @@ module.exports = async function * (source, ipld, options = {}) {
 
   if (options.format) {
     opts.codec = options.format
+  }
+
+  let dagBuilder
+
+  if (typeof options.dagBuilder === 'function') {
+    dagBuilder = options.dagBuilder
+  } else {
+    dagBuilder = require('./dag-builder')
+  }
+
+  let treeBuilder
+
+  if (typeof options.treeBuilder === 'function') {
+    treeBuilder = options.treeBuilder
+  } else {
+    treeBuilder = require('./tree-builder')
   }
 
   for await (const entry of treeBuilder(parallelBatch(dagBuilder(source, ipld, opts), opts.fileImportConcurrency), ipld, opts)) {

--- a/test/chunker-custom.spec.js
+++ b/test/chunker-custom.spec.js
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+'use strict'
+
+const importer = require('../src')
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
+const mc = require('multicodec')
+
+// eslint bug https://github.com/eslint/eslint/issues/12459
+// eslint-disable-next-line require-await
+const iter = async function * () {
+  yield Buffer.from('one')
+  yield Buffer.from('two')
+}
+
+describe('custom chunker', function () {
+  let inmem
+
+  const fromPartsTest = (iter, size) => async () => {
+    for await (const part of importer([{
+      content: iter()
+    }], inmem, {
+      chunkValidator: source => source,
+      chunker: source => source,
+      bufferImporter: async function * (file, source, ipld, options) {
+        for await (const item of source) {
+          yield () => Promise.resolve(item)
+        }
+      }
+    })) {
+      expect(part.size).to.equal(size)
+    }
+  }
+
+  before(async () => {
+    inmem = await inMemory(IPLD)
+  })
+
+  it('keeps custom chunking', async () => {
+    const chunker = source => source
+    const content = iter()
+    for await (const part of importer([{ path: 'test', content }], inmem, {
+      chunker
+    })) {
+      expect(part.size).to.equal(116)
+    }
+  })
+
+  // eslint bug https://github.com/eslint/eslint/issues/12459
+  const multi = async function * () {
+    yield {
+      size: 11,
+      cid: await inmem.put(Buffer.from('hello world'), mc.RAW)
+    }
+    yield {
+      size: 11,
+      cid: await inmem.put(Buffer.from('hello world'), mc.RAW)
+    }
+  }
+  it('works with multiple parts', fromPartsTest(multi, 120))
+
+  const single = async function * () {
+    yield {
+      size: 11,
+      cid: await inmem.put(Buffer.from('hello world'), mc.RAW)
+    }
+  }
+  it('works with single part', fromPartsTest(single, 11))
+})


### PR DESCRIPTION
The interesting bits of this module are the various ways of building DAGs for files and folders (flat, sharded, etc).

Sometimes we want to utilise bits of this logic to build DAGs without having to reimplement big chunks of this module.

This PR allows the user to pass in functions to replace key parts of this import pipeline.

Enables:

* https://github.com/ipfs/js-ipfs-mfs/pull/73
* https://github.com/ipfs/js-ipfs-unixfs-importer/pull/46