### PR TITLE
fix: only output unixfs things

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "ipld-in-memory": "^3.0.0",
     "it-buffer-stream": "^1.0.0",
     "it-last": "^1.0.0",
-    "multihashes": "^0.4.14",
     "nyc": "^15.0.0",
     "sinon": "^8.0.4"
   },

--- a/src/utils/persist.js
+++ b/src/utils/persist.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const mh = require('multihashes')
+const mh = require('multihashing-async').multihash
 const mc = require('multicodec')
 
 const persist = (node, ipld, options) => {

--- a/test/builder.spec.js
+++ b/test/builder.spec.js
@@ -4,7 +4,7 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
-const mh = require('multihashes')
+const mh = require('multihashing-async').multihash
 const IPLD = require('ipld')
 const inMemory = require('ipld-in-memory')
 const UnixFS = require('ipfs-unixfs')

--- a/test/chunker-custom.spec.js
+++ b/test/chunker-custom.spec.js
@@ -69,5 +69,5 @@ describe('custom chunker', function () {
       cid: await inmem.put(Buffer.from('hello world'), mc.RAW)
     }
   }
-  it('works with single part', fromPartsTest(single, 11))
+  it('works with single part', fromPartsTest(single, 19))
 })

--- a/test/importer.spec.js
+++ b/test/importer.spec.js
@@ -260,7 +260,7 @@ strategies.forEach((strategy) => {
       type: 'directory'
     },
     '200Bytes.txt with raw leaves': extend({}, baseFiles['200Bytes.txt'], {
-      cid: 'zb2rhXrz1gkCv8p4nUDZRohY6MzBE9C3HVTVDP72g6Du3SD9Q',
+      cid: 'QmQmZQxSKQppbsWfVzBvg59Cn3DKtsNVQ94bjAxg2h3Lb8',
       size: 200
     })
   }, strategyOverrides[strategy])


### PR DESCRIPTION
This is a `unixfs-importer` but it's possible to output CIDs that resolve to `dag-raw` nodes if your data is small and you set `rawLeaves` and `reduceSingleLeafToSelf` to true. In that case you'll get a `dag-raw` node as the output.

This makes it impossible to set metadata on small files with `rawLeaves` set to true.

BREAKING CHANGE:

If your data is below the chunk size, and you have `rawLeaves` and `reduceSingleLeafToSelf` set to true, you'll get a CID that resolves to a bona fide UnixFS file back with metadata and all that good stuff instead of a `dag-raw` node.