### PR TITLE
perf: small bl

### DIFF
--- a/src/chunker/fixed-size.js
+++ b/src/chunker/fixed-size.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const BufferList = require('bl')
+const BufferList = require('bl/BufferList')
 
 module.exports = async function * fixedSizeChunker (source, options) {
   let bl = new BufferList()

--- a/src/chunker/rabin.js
+++ b/src/chunker/rabin.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const BufferList = require('bl')
+const BufferList = require('bl/BufferList')
 const { create } = require('rabin-wasm')
 const errcode = require('err-code')
 


### PR DESCRIPTION
This imports the `BufferList` class that does not extend duplex stream. This gets us one step closer to removing readable-stream from the bundle.